### PR TITLE
Replace reporter with report composer

### DIFF
--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -464,6 +464,17 @@ type ReportersArguments = {
   }
 }
 
+export type Report = {
+  details: object
+  level: string
+  msg?: string
+}
+
+export type ReportComposer = <E extends keyof ReportersArguments>(
+  event: E,
+  payload: ReportersArguments[E]
+) => Report | void
+
 export type Reporter = <E extends keyof ReportersArguments>(
   event: E,
   payload: ReportersArguments[E]

--- a/bind-backend-proxy/index.test.ts
+++ b/bind-backend-proxy/index.test.ts
@@ -64,7 +64,7 @@ function createReporter (opts: TestServerOptions = {}) {
   let reports: [string, object][] = []
   let app = createServer({
     ...opts,
-    reporter (name: string, details: any) {
+    reportComposer (name: string, details: any) {
       names.push(name)
       reports.push([name, details])
     }

--- a/create-reporter/index.js
+++ b/create-reporter/index.js
@@ -220,11 +220,20 @@ function createLogger (options) {
   )
 }
 
+function defaultReportComposer (type, details) {
+  let report = REPORTERS[type](details)
+  return {
+    level: report.level || 'info',
+    msg: report.msg,
+    details: report.details || details || {}
+  }
+}
+
 function createReporter (options) {
+  let reportComposer = options.reportComposer || defaultReportComposer
   function reporter (type, details) {
-    let report = REPORTERS[type](details)
-    let level = report.level || 'info'
-    reporter.logger[level](report.details || details || {}, report.msg)
+    let report = reportComposer(type, details)
+    if (report) reporter.logger[report.level](report.details, report.msg)
   }
   reporter.logger =
     typeof options.logger === 'object' ? options.logger : createLogger(options)

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export { ServerOptions } from './server'
 export {
   LoguxAction,
   LoguxProcessedAction,
-  Reporter,
+  ReportComposer,
   LoguxSubscribeAction,
   LoguxAnySubscribeAction,
   LoguxUndoAction,

--- a/server/__snapshots__/index.test.ts.snap
+++ b/server/__snapshots__/index.test.ts.snap
@@ -221,7 +221,7 @@ exports[`writes to pino log 1`] = `
 "
 `;
 
-exports[`writes using custom reporter 1`] = `
+exports[`writes using custom report composer 1`] = `
 "Event: listen
 Details: {\\"controlMask\\":\\"127.0.0.1/8\\",\\"loguxServer\\":\\"0.0.0\\",\\"environment\\":\\"test\\",\\"subprotocol\\":\\"1.0.0\\",\\"supports\\":\\"1.x\\",\\"server\\":false,\\"nodeId\\":\\"server:FnXaqDxY\\",\\"notes\\":{},\\"cert\\":false,\\"host\\":\\"127.0.0.1\\",\\"port\\":2000}
 Event: destroy

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1,7 +1,12 @@
-import BaseServer, { Logger, Reporter, BaseServerOptions } from '../base-server'
+import BaseServer, {
+  Logger,
+  BaseServerOptions,
+  ReportComposer
+} from '../base-server'
 
 export type ServerOptions = BaseServerOptions & {
   /**
+   * TODO [sl.aleksandr 06.05.2020] Update docs
    * Custom reporter for process/errors. You should use it only for test purposes
    * or unavoidable hacks.
    *
@@ -15,7 +20,7 @@ export type ServerOptions = BaseServerOptions & {
    * })
    * ```
    */
-  reporter?: Reporter
+  reportComposer?: ReportComposer
 
   /**
    * Stream to be used by reporter to write log.

--- a/server/index.js
+++ b/server/index.js
@@ -133,10 +133,9 @@ class Server extends BaseServer {
   constructor (opts) {
     if (!opts) opts = {}
 
-    if (typeof opts.reporter !== 'function') {
-      opts.logger = opts.logger || 'human'
-      opts.reporter = createReporter(opts)
-    }
+    opts.logger = opts.logger || 'human'
+    opts.reporter = createReporter(opts)
+    delete opts.reportComposer
 
     let initialized = false
     let onError = err => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -259,4 +259,5 @@ it('writes to pino log', () => checkOut('pino.js'))
 
 it('writes to custom pino log', () => checkOut('pino-custom.js'))
 
-it('writes using custom reporter', () => checkOut('custom-reporter.js'))
+it('writes using custom report composer', () =>
+  checkOut('custom-report-composer.js'))

--- a/test-server/index.d.ts
+++ b/test-server/index.d.ts
@@ -4,7 +4,7 @@ import TestClient, { TestClientOptions } from '../test-client'
 import BaseServer, {
   ServerMeta,
   BaseServerOptions,
-  Reporter
+  ReportComposer
 } from '../base-server'
 
 export type TestServerOptions = Omit<
@@ -21,8 +21,9 @@ export type TestServerOptions = Omit<
 
   /**
    * Low-level API to server logs for tests.
+   * TODO [sl.aleksandr 06.05.2020] Update docs
    */
-  reporter?: Reporter
+  reportComposer?: ReportComposer
 
   /**
    * Stream to be used by reporter to write log.

--- a/test-server/index.js
+++ b/test-server/index.js
@@ -9,7 +9,7 @@ class TestServer extends BaseServer {
     if (!opts.time) {
       opts.time = new TestTime()
     }
-    if (opts.logger === 'human') {
+    if (opts.reportComposer || opts.logger) {
       opts.reporter = createReporter(opts)
     }
     opts.time.lastId += 1

--- a/test/servers/custom-report-composer.js
+++ b/test/servers/custom-report-composer.js
@@ -6,7 +6,7 @@ let app = new Server({
   subprotocol: '1.0.0',
   supports: '1.x',
   port: 2000,
-  reporter: (name, details) => {
+  reportComposer: (name, details) => {
     console.log('Event:', name)
     console.log('Details:', JSON.stringify(details))
   }


### PR DESCRIPTION
**Problem:** you can pass custom reporter and custom logger simultaneously, and last one will be ignored. 


Also allow to change report formats (e.g. details) and still use built-in logger